### PR TITLE
Fix retain, case insensitive commands, unregister on stop

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,10 @@ MQTT.prototype.init = function (config) {
         var topic = self.createTopic(device);
         var value = device.get('metrics:level');
         if (!device.get('permanently_hidden')) {
+            if (self.config.ignore_global_room && device.get('location') == 0) {
+                self.verbose('self.config.ignore_global_room set to: ' + self.config.ignore_global_room+' and device.location ' +device.location+' so ignoring');
+                return;
+            }
             if (self.status[topic] === undefined
                 || value != self.status[topic].value
                 || (DIRECT_DEVICES.indexOf(device.get('deviceType')) >= 0
@@ -119,3 +123,8 @@ MQTT.prototype.init = function (config) {
     }
 };
 
+MQTT.prototype.stop = function () {
+    MQTT.super_.prototype.stop.call(this);
+    this.controller.devices.off('change:metrics:level', this.deviceUpdate);
+    console.log('MQTT: stopped');
+};

--- a/module.json
+++ b/module.json
@@ -22,7 +22,8 @@
     "mqtt_retain": "0",
     "zway_user": "admin",
     "zway_password": "",
-    "verbose": true
+    "verbose": true,
+    "ignore_global_room": true
   },
   "schema": {
     "type": "object",
@@ -61,6 +62,9 @@
         "required": true
       },
       "verbose": {
+        "required": false
+      },
+      "ignore_global_room": {
         "required": false
       }
     },
@@ -116,6 +120,11 @@
       },
       "verbose": {
         "label": "Verbose",
+        "type": "checkbox",
+        "required": false
+      },
+      "ignore_global_room": {
+        "label": "Only publish state of devices assigned to a room",
         "type": "checkbox",
         "required": false
       }

--- a/zway_mqtt_http_bridge.py
+++ b/zway_mqtt_http_bridge.py
@@ -77,7 +77,7 @@ class ZwayMqttHttpBride:
         url = self.api_url + '/devices/' + device_id + '/command/'
         if value.isdigit():
             url += 'exact?level='
-        url += value
+        url += value.lower()
         response = requests.get(url, headers={'ZWAYSession': self.api_sid})
         if response.status_code == 200:
             self.verbose('did update device: ' + url)
@@ -91,7 +91,7 @@ class ZwayMqttHttpBride:
         self.config = config
         self.mqtt_qos_publish = int(self.config['mqtt_qos_publish']) if 'mqtt_qos_publish' in config else 0
         self.mqtt_qos_subscribe = int(self.config['mqtt_qos_subscribe']) if 'mqtt_qos_subscribe' in config else 0
-        self.mqtt_retain = 'mqtt_retain' in config and 'true' == self.config['mqtt_retain']
+        self.mqtt_retain = 'mqtt_retain' in config and self.config['mqtt_retain']
         if 'api_url' in config:
             self.api_url = config['api_url']
 


### PR DESCRIPTION
- Fix MQTT retain functionality
- Allow upper or lower case on/off commands to be sent in the payload of the set message
- When plugin stops, now unregisters from device updates.  Issue found when restarting plugin as events would be duplicated on MQTT.